### PR TITLE
Expose error details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
 language: ruby
+sudo: false
+cache: bundler
+bundler_args: --without development --retry=3 --jobs=3
+
 rvm:
-  - 2.2
-  - 2.1
-  - 2.0
   - 1.9
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - ruby-head
+
+matrix:
+  allow_failures:
+    - 1.9
+    - 2.0
+    - ruby-head
+  fast_finish: true

--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday_middleware', '~> 0.10')
   s.add_runtime_dependency('multi_json', '~> 1.11')
   s.add_runtime_dependency('hashie',  '~> 3.0')
-  s.authors = ["Shayne Sweeney"]
+  s.authors = ["Shayne Sweeney", "Jason Dugdale"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}
   s.post_install_message =<<eos
 ********************************************************************************

--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -11,21 +11,21 @@ module FaradayMiddleware
       @app.call(env).on_complete do |response|
         case response[:status].to_i
         when 400
-          raise Instagram::BadRequest, error_message_400(response)
+          raise Instagram::BadRequest, response
         when 403
-          raise Instagram::Forbidden, error_message_400(response)
+          raise Instagram::Forbidden, response
         when 404
-          raise Instagram::NotFound, error_message_400(response)
+          raise Instagram::NotFound, response
         when 429
-          raise Instagram::TooManyRequests, error_message_400(response)
+          raise Instagram::TooManyRequests, response
         when 500
-          raise Instagram::InternalServerError, error_message_500(response, "Something is technically wrong.")
+          raise Instagram::InternalServerError, response
         when 502
-          raise Instagram::BadGateway, error_message_500(response, "The server returned an invalid or incomplete response.")
+          raise Instagram::BadGateway, response
         when 503
-          raise Instagram::ServiceUnavailable, error_message_500(response, "Instagram is rate limiting your requests.")
+          raise Instagram::ServiceUnavailable, response
         when 504
-          raise Instagram::GatewayTimeout, error_message_500(response, "504 Gateway Time-out")
+          raise Instagram::GatewayTimeout, response
         end
       end
     end
@@ -33,41 +33,6 @@ module FaradayMiddleware
     def initialize(app)
       super app
       @parser = nil
-    end
-
-    private
-
-    def error_message_400(response)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{response[:status]}#{error_body(response[:body])}"
-    end
-
-    def error_body(body)
-      # body gets passed as a string, not sure if it is passed as something else from other spots?
-      if not body.nil? and not body.empty? and body.kind_of?(String)
-        # removed multi_json thanks to wesnolte's commit
-        body = begin
-          ::JSON.parse(body)
-        rescue JSON::ParserError => e
-          # handle HTML response here as empty JSON
-          if e.message.match /unexpected token/
-            nil
-          else
-            raise e
-          end
-        end
-      end
-
-      if body.nil?
-        nil
-      elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
-        ": #{body['meta']['error_message']}"
-      elsif body['error_message'] and not body['error_message'].empty?
-        ": #{body['error_type']}: #{body['error_message']}"
-      end
-    end
-
-    def error_message_500(response, body=nil)
-      "#{response[:method].to_s.upcase} #{response[:url].to_s}: #{[response[:status].to_s + ':', body].compact.join(' ')}"
     end
   end
 end

--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -185,7 +185,7 @@ module Instagram
           verify_signature = OpenSSL::HMAC.hexdigest(digest, client_secret, json)
 
           if options[:signature] != verify_signature
-            raise Instagram::InvalidSignature, "invalid X-Hub-Signature does not match verify signature against client_secret"
+            raise Instagram::InvalidSignature, {body: "invalid X-Hub-Signature does not match verify signature against client_secret"}
           end
         end
 

--- a/lib/instagram/error.rb
+++ b/lib/instagram/error.rb
@@ -1,6 +1,53 @@
 module Instagram
   # Custom error class for rescuing from all Instagram errors
-  class Error < StandardError; end
+  class Error < StandardError
+    attr_reader :http_body
+    attr_reader :http_headers
+    attr_reader :http_status
+    attr_reader :json_body
+    attr_reader :method
+    attr_reader :request_url
+
+    def initialize(response={})
+      @http_body = error_body(response[:body]) || ""
+      @http_headers = response[:response_headers] || {}
+      @http_status = response[:status] || nil
+      @json_body = response[:body] || ""
+      @method = response[:method].to_s.upcase || ""
+      @request_url = response[:url].to_s || ""
+    end
+
+    def to_s
+      "#{@method} #{@request_url}: #{@http_status}: #{@http_body}"
+    end
+
+    private
+
+    def error_body(body)
+      # body gets passed as a string, not sure if it is passed as something else from other spots?
+      if not body.nil? and not body.empty? and body.kind_of?(String)
+        # removed multi_json thanks to wesnolte's commit
+        body = begin
+          ::JSON.parse(body)
+        rescue JSON::ParserError => e
+          # Pass HTML or plain text response back
+          if e.message.match /unexpected token/
+            body
+          else
+            raise e
+          end
+        end
+      end
+
+      if body.nil?
+        nil
+      elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
+        "#{body['meta']['error_message']}"
+      elsif body['error_message'] and not body['error_message'].empty?
+        "#{body['error_type']}: #{body['error_message']}"
+      end
+    end
+  end
 
   # Raised when Instagram returns the HTTP status code 400
   class BadRequest < Error; end
@@ -15,16 +62,32 @@ module Instagram
   class TooManyRequests < Error; end
 
   # Raised when Instagram returns the HTTP status code 500
-  class InternalServerError < Error; end
+  class InternalServerError < Error
+    def initialize(response)
+      super(response.merge(body: 'Something is technically wrong.'))
+    end
+  end
 
   # Raised when Instagram returns the HTTP status code 502
-  class BadGateway < Error; end
+  class BadGateway < Error
+    def initialize(response)
+      super(response.merge(body: 'The server returned an invalid or incomplete response.'))
+    end
+  end
 
   # Raised when Instagram returns the HTTP status code 503
-  class ServiceUnavailable < Error; end
+  class ServiceUnavailable < Error
+    def initialize(response)
+      super(response.merge(body: 'Instagram is rate limiting your requests or having internal issues.'))
+    end
+  end
 
   # Raised when Instagram returns the HTTP status code 504
-  class GatewayTimeout < Error; end
+  class GatewayTimeout < Error;
+    def initialize(response)
+      super(response.merge(body: '504 Gateway Time-out'))
+    end
+  end
 
   # Raised when a subscription payload hash is invalid
   class InvalidSignature < Error; end

--- a/lib/instagram/version.rb
+++ b/lib/instagram/version.rb
@@ -1,3 +1,3 @@
 module Instagram
-  VERSION = '1.1.6'.freeze unless defined?(::Instagram::VERSION)
+  VERSION = '1.2.0'.freeze unless defined?(::Instagram::VERSION)
 end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -11,7 +11,9 @@ describe Faraday::Response do
     404 => Instagram::NotFound,
     429 => Instagram::TooManyRequests,
     500 => Instagram::InternalServerError,
-    503 => Instagram::ServiceUnavailable
+    502 => Instagram::BadGateway,
+    503 => Instagram::ServiceUnavailable,
+    504 => Instagram::GatewayTimeout
   }.each do |status, exception|
     context "when HTTP status is #{status}" do
 
@@ -24,6 +26,19 @@ describe Faraday::Response do
         expect do
           @client.user_media_feed()
         end.to raise_error(exception)
+      end
+
+      [
+        :http_body,
+        :http_headers,
+        :http_status,
+        :json_body,
+        :method,
+        :request_url
+      ].each do |attribute|
+        it "#{exception.name} should respond to :#{attribute}" do
+          expect(exception.new({})).to respond_to(attribute.to_sym)
+        end
       end
 
     end


### PR DESCRIPTION
## Added
- We've added some attributes to `Instagram::Error` objects. You can now get the following elements of an error:
  + attr_reader :http_body
  + attr_reader :http_headers
  + attr_reader :http_status
  + attr_reader :json_body
  + attr_reader :method
  + attr_reader :request_url

## Changed
- `Instagram::Error` now requires a `response` object to be passed. It can handle an empty `Hash` if you've not made an HTTP request
- Modernized `.travis.yml`
- Importantly, this is backward-compatible. Calling `Instagram::Error.new({}).to_s` will look exactly the same before and after these changes:

**Existing version:**
```
[1] pry(main)> require 'instagram'
=> true
[2] pry(main)>
[3] pry(main)> Instagram::VERSION
=> "1.1.6"
[4] pry(main)>
[5] pry(main)> begin
[5] pry(main)*   c = Instagram.client(access_token: '<TOKEN>')
[5] pry(main)*   c.tag_recent_media('wtf', {count: 1})
[5] pry(main)* rescue Exception => e
[5] pry(main)*   puts e.inspect
[5] pry(main)*   puts e.http_status
[5] pry(main)* end
#<Instagram::BadRequest: GET https://api.instagram.com/v1/tags/wtf/media/recent.json?access_token=<TOKEN>&count=1: 400: This tag cannot be viewed>
NoMethodError: undefined method `http_status' for #<Instagram::BadRequest:0x007fc81346e618>
from (pry):8:in `rescue in __pry__'
[6] pry(main)>
```

**Proposed changes:**
```
[1] pry(main)> require 'instagram'
=> true
[2] pry(main)>
[3] pry(main)> Instagram::VERSION
=> "1.2.0"
[4] pry(main)>
[5] pry(main)> begin
[5] pry(main)*   c = Instagram.client(access_token: '<TOKEN>')
[5] pry(main)*   c.tag_recent_media('wtf', {count: 1})
[5] pry(main)* rescue Exception => e
[5] pry(main)*   puts e.inspect
[5] pry(main)*   puts e.http_status
[5] pry(main)* end
#<Instagram::BadRequest: GET https://api.instagram.com/v1/tags/wtf/media/recent.json?access_token=<TOKEN>&count=1: 400: This tag cannot be viewed>
400
=> nil
[6] pry(main)>
```
